### PR TITLE
Added optional  argument to change the separator to ','.

### DIFF
--- a/jira_metrics_extract/cli.py
+++ b/jira_metrics_extract/cli.py
@@ -194,7 +194,7 @@ def main(argv=None):
 
     output_format = args.format.lower() if args.format is not None else 'csv'
     output_separator = '\t' # Default separator is \t
-    output_separator = ',' if (args.separator is not None and args.separator.lower()) == 'comma' else '\t'
+    output_separator = ',' if (args.separator is not None and args.separator.lower() == 'comma') else '\t'
 
     throughput_window_end = parse_relative_date(args.throughput_window_end) if args.throughput_window_end else datetime.date.today()
     throughput_window_days = args.throughput_window

--- a/jira_metrics_extract/cli.py
+++ b/jira_metrics_extract/cli.py
@@ -194,7 +194,7 @@ def main(argv=None):
 
     output_format = args.format.lower() if args.format is not None else 'csv'
     output_separator = '\t' # Default separator is \t
-    output_separator = ',' if args.output_separator is not None and args.output_separator.lower() == 'comma'
+    output_separator = ',' if (args.separator is not None and args.separator.lower()) == 'comma' else '\t'
 
     throughput_window_end = parse_relative_date(args.throughput_window_end) if args.throughput_window_end else datetime.date.today()
     throughput_window_days = args.throughput_window


### PR DESCRIPTION
CSV files should be comma separated. Even though using `\t` as a separator works, it ruins the formatting while opening it in MS Excel or similar spreadsheet. 

Added an option `--separator` to allow this.

**The default separator still remains `\t`.**